### PR TITLE
fix: add support for http -> https redirect

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,14 @@ repos:
       - id: no-commit-to-branch
         args: ["--branch", "main"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.14
+    # Ruff version.
+    rev: v0.6.2
     hooks:
+      # Run the linter.
       - id: ruff
-        args: ["--fix", "."]
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/docs/src/app/reference/aws-resources/acm/page.md
+++ b/docs/src/app/reference/aws-resources/acm/page.md
@@ -1,0 +1,36 @@
+## ACMCertificate
+
+An ACM Certificate resource.
+
+**Note:** This Resource is in beta and is likely to change in the future.
+
+For more information see [the official documentation](https://docs.aws.amazon.com/acm/).
+
+### Example Usage
+```python
+import launchflow as lf
+
+certificate = lf.aws.ACMCertificate("my-certificate")
+```
+
+### initialization
+
+Creates a new ACM Certificate resource.
+
+**Args:**
+- `name (str)`: The name of the resource.
+- `domain_name (str)`: The domain name to use for the certificate.
+
+### inputs
+
+```python
+ACMCertificate.inputs(environment_state: EnvironmentState) -> ACMCertificateInputs
+```
+
+Get the inputs for the ACM Certificate.
+
+**Args:**
+- `environment_state (EnvironmentState)`: The environment to get inputs for.
+
+**Returns:**
+- An `ACMCertificateInputs` object containing the inputs for the ACM Certificate.

--- a/docs/src/app/reference/aws-resources/alb/page.md
+++ b/docs/src/app/reference/aws-resources/alb/page.md
@@ -1,0 +1,38 @@
+## ApplicationLoadBalancer
+
+An Application Load Balancer.
+
+**Note:** This Resource is in beta and is likely to change in the future.
+
+For more information see [the official documentation](https://docs.aws.amazon.com/elasticloadbalancing/).
+
+## Example Usage
+```python
+import launchflow as lf
+
+alb = lf.aws.ApplicationLoadBalancer("my-lb", health_check_path='/health')
+```
+
+### initialization
+
+Creates a new Application Load Balancer.
+
+**Args:**
+- `name (str)`: The name of the Application Load Balancer.
+- `container_port (int)`: The port that the container listens on.
+- `health_check_path (Optional[str])`: The path to use for the health check
+- `certificate (Optional[ACMCertificate])`: The certificate to use for the ALB.
+
+### inputs
+
+```python
+ApplicationLoadBalancer.inputs(environment_state: EnvironmentState) -> ApplicationLoadBalancerInputs
+```
+
+Get the inputs for the Application Load Balancer resource.
+
+**Args:**
+- `environment_state (EnvironmentState)`: The environment to get inputs for.
+
+**Returns:**
+- An `ApplicationLoadBalancerInputs` object containing the inputs for the ALB.

--- a/docs/src/app/reference/aws-services/ecs-fargate/page.md
+++ b/docs/src/app/reference/aws-services/ecs-fargate/page.md
@@ -35,3 +35,4 @@ Creates a new ECS Fargate service.
 - `build_directory (str)`: The directory to build the service from. This should be a relative path from the project root where your `launchflow.yaml` is defined.
 - `dockerfile (str)`: The Dockerfile to use for building the service. This should be a relative path from the `build_directory`.
 - `build_ignore (List[str])`: A list of files to ignore when building the service. This can be in the same syntax you would use for a `.gitignore`.
+- `domain (Optional[str])`: The domain name to use for the service. This will create an ACM certificate and configure the ALB to use HTTPS.

--- a/docs/src/app/reference/gcp-resources/custom-domain-mapping/page.md
+++ b/docs/src/app/reference/gcp-resources/custom-domain-mapping/page.md
@@ -17,9 +17,11 @@ Create a new CustomDomainMapping resource.
 
 **Args:**
 - `name` (str): The name of the CustomDomainMapping resource. This must be globally unique.
-- `domain` (str): The domain to map to the Cloud Run service.
+- `ssl_certificate (ManagedSSLCertificate):` The [SSL certificate](/reference/gcp-resources/ssl) to use for the domain.
+- `ip_address (GlobalIPAddress)`: The [IP address](/reference/gcp-resources/global-ip-address) to map the domain to.
 - `cloud_run` (CloudRunServiceContainer): The Cloud Run service to map the domain to. One and only one of cloud_run and gce_service must be provided.
 - `regional_managed_instance_group` (RegionalManagedInstanceGroup): The Compute Engine service to map the domain to. One and only one of cloud_run and gce_service must be provided.
+- `include_http_redirect` (bool): Whether to include an HTTP redirect to the HTTPS URL. Defaults to True.
 
 ### inputs
 

--- a/docs/src/app/reference/gcp-resources/firebase/page.md
+++ b/docs/src/app/reference/gcp-resources/firebase/page.md
@@ -1,0 +1,15 @@
+## FirebaseHostingSite
+
+### initialization
+
+Create a new Firebase Hosting Site resource.
+**Args:**
+- `name (str)`: The name of the Firebase site.
+
+## FirebaseProject
+
+### initialization
+
+Create a new Firebase Project resource.
+**Args:**
+- `name (str)`: The name of the Firebase project.

--- a/docs/src/app/reference/gcp-resources/gcs/page.md
+++ b/docs/src/app/reference/gcp-resources/gcs/page.md
@@ -1,3 +1,14 @@
+## BackendBucket
+
+### initialization
+
+Create a new GCS Backend Bucket resource.
+**Args:**
+- `name (str)`: The name of the bucket. This must be globally unique.
+- `location (str)`: The location of the bucket. Defaults to "US".
+- `force_destroy (bool)`: If true, the bucket will be destroyed even if it's not empty. Defaults to False.
+- `custom_domain (Optional[str])`: A custom domain to map to the bucket
+
 ## GCSBucket
 
 A storage bucket in Google Cloud Storage.

--- a/docs/src/app/reference/gcp-resources/global-ip-address/page.md
+++ b/docs/src/app/reference/gcp-resources/global-ip-address/page.md
@@ -1,0 +1,21 @@
+## GlobalIPAddress
+
+A global ip address resource.
+
+Like all [Resources](/docs/concepts/resources), this class configures itself across multiple [Environments](/docs/concepts/environments).
+
+For more information see [the official documentation](https://cloud.google.com/compute/docs/ip-addresses).
+
+### Example Usage
+```python
+import launchflow as lf
+
+ip = lf.gcp.GlobalIPAddress("ip-addres")
+```
+
+### initialization
+
+Create a new Global IP Address resource.
+
+**Args:**
+- `name (str)`: The name of the ip address.

--- a/docs/src/app/reference/gcp-resources/ssl/page.md
+++ b/docs/src/app/reference/gcp-resources/ssl/page.md
@@ -1,0 +1,22 @@
+## ManagedSSLCertificate
+
+A manage ssl certificate resource.
+
+Like all [Resources](/docs/concepts/resources), this class configures itself across multiple [Environments](/docs/concepts/environments).
+
+For more information see [the official documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs).
+
+### Example Usage
+```python
+import launchflow as lf
+
+ip = lf.gcp.GlobalIPAddress("ip-addres")
+```
+
+### initialization
+
+Create a new managed ssl certificate resource.
+
+**Args:**
+- `name (str)`: The name of the ip address.
+- `domain (str)`: The domain of the ssl certificate.

--- a/docs/src/app/reference/gcp-services/firebase-site/page.md
+++ b/docs/src/app/reference/gcp-services/firebase-site/page.md
@@ -1,0 +1,21 @@
+## FirebaseStaticSite
+
+A service hosted on Firebase Hosting.
+
+### Example Usage
+```python
+import launchflow as lf
+
+website = lf.gcp.FirebaseStaticSite("my-website", static_directory="path/to/local/files")
+```
+
+### initialization
+
+Creates a new Cloud Run service.
+
+**Args:**
+- `name (str)`: The name of the service.
+- `static_directory (str)`: The directory of static files to serve. This should be a relative path from the project root where your `launchflow.yaml` is defined.
+- `static_ignore (List[str])`: A list of files to ignore when deploying the service. This can be in the same syntax you would use for a `.gitignore`.
+- `region (Optional[str])`: The region to deploy the service to.
+- `domain (Optional[str])`: The custom domain to map to the service.

--- a/docs/src/app/reference/gcp-services/static-site/page.md
+++ b/docs/src/app/reference/gcp-services/static-site/page.md
@@ -1,0 +1,21 @@
+## StaticSite
+
+A service hosted on Google Cloud Platform that serves static files.
+
+### Example Usage
+```python
+import launchflow as lf
+
+website = lf.gcp.StaticSite("my-website", static_directory="path/to/local/files")
+```
+
+### initialization
+
+Creates a new Cloud Run service.
+
+**Args:**
+- `name (str)`: The name of the service.
+- `static_directory (str)`: The directory of static files to serve. This should be a relative path from the project root where your `launchflow.yaml` is defined.
+- `static_ignore (List[str])`: A list of files to ignore when deploying the service. This can be in the same syntax you would use for a `.gitignore`.
+- `region (Optional[str])`: The region to deploy the service to.
+- `domain (Optional[str])`: The custom domain to map to the service.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -116,6 +116,14 @@ export const referenceNavigation = [
         title: 'HTTP Health Check',
         href: '/reference/gcp-resources/http-health-check',
       },
+      {
+        title: 'SSL Certificates',
+        href: '/reference/gcp-resources/ssl',
+      },
+      {
+        title: 'Global IP Address',
+        href: '/reference/gcp-resources/global-ip-address',
+      },
     ].sort((a, b) => a.title.localeCompare(b.title)),
   },
   {

--- a/launchflow/aws/alb.py
+++ b/launchflow/aws/alb.py
@@ -1,3 +1,4 @@
+import hashlib
 from dataclasses import dataclass
 from typing import Optional
 
@@ -8,7 +9,6 @@ from launchflow.models.enums import ResourceProduct
 from launchflow.models.flow_state import EnvironmentState
 from launchflow.node import Depends, Outputs
 from launchflow.resource import ResourceInputs
-import hashlib
 
 
 @dataclass

--- a/launchflow/flows/create_flows.py
+++ b/launchflow/flows/create_flows.py
@@ -23,34 +23,51 @@ from launchflow.cli.resource_utils import is_secret_resource
 from launchflow.clients.docker_client import docker_service_available
 from launchflow.config import config
 from launchflow.docker.resource import DockerResource
-from launchflow.flows.flow_utils import (OP_COLOR, ResourceRef, ServiceRef,
-                                         compare_dicts, dump_verbose_logs,
-                                         format_configuration_dict)
-from launchflow.flows.plan import (FailedToPlan, FlowResult, ResourcePlan,
-                                   Result, ServicePlan, execute_plans)
+from launchflow.flows.flow_utils import (
+    OP_COLOR,
+    ResourceRef,
+    ServiceRef,
+    compare_dicts,
+    dump_verbose_logs,
+    format_configuration_dict,
+)
+from launchflow.flows.plan import (
+    FailedToPlan,
+    FlowResult,
+    ResourcePlan,
+    Result,
+    ServicePlan,
+    execute_plans,
+)
 from launchflow.flows.plan_utils import lock_plans, print_plans, select_plans
 from launchflow.locks import Lock, LockOperation, OperationType, ReleaseReason
 from launchflow.logger import logger
 from launchflow.managers.environment_manager import EnvironmentManager
 from launchflow.managers.resource_manager import ResourceManager
 from launchflow.managers.service_manager import ServiceManager
-from launchflow.models.enums import (CloudProvider, EnvironmentStatus,
-                                     ResourceProduct, ResourceStatus,
-                                     ServiceProduct, ServiceStatus)
-from launchflow.models.flow_state import (EnvironmentState, ResourceState,
-                                          ServiceState)
+from launchflow.models.enums import (
+    CloudProvider,
+    EnvironmentStatus,
+    ResourceProduct,
+    ResourceStatus,
+    ServiceProduct,
+    ServiceStatus,
+)
+from launchflow.models.flow_state import EnvironmentState, ResourceState, ServiceState
 from launchflow.models.launchflow_uri import LaunchFlowURI
 from launchflow.node import Node
 from launchflow.resource import Resource
 from launchflow.service import DNSOutputs, Service
 from launchflow.tofu import TofuResource
 from launchflow.validation import validate_resource_name, validate_service_name
-from launchflow.workflows.apply_resource_tofu.create_tofu_resource import \
-    create_tofu_resource
+from launchflow.workflows.apply_resource_tofu.create_tofu_resource import (
+    create_tofu_resource,
+)
 from launchflow.workflows.manage_docker.manage_docker_resources import (
-    create_docker_resource, replace_docker_resource)
-from launchflow.workflows.manage_docker.schemas import \
-    CreateResourceDockerInputs
+    create_docker_resource,
+    replace_docker_resource,
+)
+from launchflow.workflows.manage_docker.schemas import CreateResourceDockerInputs
 
 
 @dataclasses.dataclass
@@ -781,7 +798,10 @@ async def plan_create_resource(
         existing_resource_state = None
 
     if existing_resource_state is not None:
-        if existing_resource_state.product != resource.product:
+        if (
+            existing_resource_state.product != resource.product
+            and existing_resource_state.product != ResourceProduct.UNKNOWN
+        ):
             exception = exceptions.ResourceProductMismatch(
                 resource=resource,
                 existing_product=existing_resource_state.product,
@@ -875,9 +895,9 @@ async def plan_create_resources(
                     dependency_plan
                 )
                 if isinstance(resolved_dependency_plan, FailedToPlan):
-                    resource_name_to_plan[
-                        resource_dependency.name
-                    ] = resolved_dependency_plan
+                    resource_name_to_plan[resource_dependency.name] = (
+                        resolved_dependency_plan
+                    )
                     return FailedToPlan(
                         resource=plan.resource,
                         error_message=f"DependencyFailedToPlan: {ResourceRef(plan.resource)} depends on {ResourceRef(resource_dependency)} which failed to plan.",

--- a/launchflow/gcp/cloud_run.py
+++ b/launchflow/gcp/cloud_run.py
@@ -8,7 +8,9 @@ from launchflow.gcp.artifact_registry_repository import (
 )
 from launchflow.gcp.cloud_run_container import CloudRunServiceContainer
 from launchflow.gcp.custom_domain_mapping import CustomDomainMapping
+from launchflow.gcp.global_ip_address import GlobalIPAddress
 from launchflow.gcp.service import GCPDockerService
+from launchflow.gcp.ssl import ManagedSSLCertificate
 from launchflow.models.enums import ServiceProduct
 from launchflow.node import Inputs
 from launchflow.resource import Resource
@@ -128,11 +130,18 @@ class CloudRun(GCPDockerService):
         self._cloud_run_service_container.resource_id = name
 
         self._custom_domain_mapping: Optional[CustomDomainMapping] = None
+        self._ip_address: Optional[GlobalIPAddress] = None
+        self._ssl_certificate: Optional[ManagedSSLCertificate] = None
 
         if domain:
+            self._ip_address = GlobalIPAddress(f"{name}-ip-address")
+            self._ssl_certificate = ManagedSSLCertificate(
+                f"{name}-ssl-certificate", domains=domain
+            )
             self._custom_domain_mapping = CustomDomainMapping(
                 f"{name}-domain-mapping",
-                domain=domain,
+                ip_address=self._ip_address,
+                ssl_certificate=self._ssl_certificate,
                 cloud_run=self._cloud_run_service_container,
             )
             self._custom_domain_mapping.resource_id = name
@@ -145,7 +154,11 @@ class CloudRun(GCPDockerService):
             self._artifact_registry,
             self._cloud_run_service_container,
         ]
-        if self._custom_domain_mapping:
+        if self._ip_address is not None:
+            to_return.append(self._ip_address)
+        if self._ssl_certificate is not None:
+            to_return.append(self._ssl_certificate)
+        if self._custom_domain_mapping is not None:
             to_return.append(self._custom_domain_mapping)
         return to_return
 
@@ -157,20 +170,8 @@ class CloudRun(GCPDockerService):
             raise exceptions.ServiceOutputsNotFound(service_name=self.name)
 
         dns_outputs = None
-        if self._custom_domain_mapping is not None:
-            try:
-                custom_domain_outputs = self._custom_domain_mapping.outputs()
-            except exceptions.ResourceOutputsNotFound:
-                raise exceptions.ServiceOutputsNotFound(service_name=self.name)
-            dns_outputs = DNSOutputs(
-                domain=custom_domain_outputs.registered_domain,
-                dns_records=[
-                    DNSRecord(
-                        dns_record_value=custom_domain_outputs.ip_address,
-                        dns_record_type="A",
-                    ),
-                ],
-            )
+        if self._custom_domain_mapping:
+            dns_outputs = self._custom_domain_mapping.dns_outputs()
 
         if artifact_registry_outputs.docker_repository is None:
             raise ValueError("Docker repository not found in artifact registry outputs")

--- a/launchflow/gcp/cloud_run.py
+++ b/launchflow/gcp/cloud_run.py
@@ -14,7 +14,7 @@ from launchflow.gcp.ssl import ManagedSSLCertificate
 from launchflow.models.enums import ServiceProduct
 from launchflow.node import Inputs
 from launchflow.resource import Resource
-from launchflow.service import DNSOutputs, DNSRecord, DockerServiceOutputs
+from launchflow.service import DockerServiceOutputs
 
 
 @dataclass

--- a/launchflow/gcp/compute_engine_service.py
+++ b/launchflow/gcp/compute_engine_service.py
@@ -2,7 +2,6 @@ import dataclasses
 from datetime import timedelta
 from typing import Any, List, Literal, Optional, Union
 
-from launchflow import exceptions
 from launchflow.gcp.artifact_registry_repository import (
     ArtifactRegistryRepository,
     RegistryFormat,
@@ -27,7 +26,7 @@ from launchflow.gcp.ssl import ManagedSSLCertificate
 from launchflow.models.enums import ServiceProduct
 from launchflow.node import Inputs
 from launchflow.resource import Resource
-from launchflow.service import DNSOutputs, DNSRecord, DockerServiceOutputs
+from launchflow.service import DockerServiceOutputs
 
 
 @dataclasses.dataclass

--- a/launchflow/gcp/custom_domain_mapping.py
+++ b/launchflow/gcp/custom_domain_mapping.py
@@ -133,11 +133,8 @@ class CustomDomainMapping(GCPResource[CustomDomainMappingOutputs]):
         )
 
     def dns_outputs(self) -> DNSOutputs:
-        try:
-            ip_outputs = self.ip_address.outputs()
-            ssl_outputs = self.ssl_certificate.outputs()
-        except exceptions.ResourceOutputsNotFound:
-            raise exceptions.ServiceOutputsNotFound(service_name=self.name)
+        ip_outputs = self.ip_address.outputs()
+        ssl_outputs = self.ssl_certificate.outputs()
         return DNSOutputs(
             domain=ssl_outputs.domains[0],
             dns_records=[

--- a/launchflow/gcp/custom_domain_mapping.py
+++ b/launchflow/gcp/custom_domain_mapping.py
@@ -33,6 +33,7 @@ class CustomDomainMappingInputs(ResourceInputs):
     health_check: Optional[str]
     region: Optional[str]
     named_port: Optional[str]
+    include_http_redirect: bool
 
 
 class CustomDomainMapping(GCPResource[CustomDomainMappingOutputs]):
@@ -57,6 +58,7 @@ class CustomDomainMapping(GCPResource[CustomDomainMappingOutputs]):
         domain: str,
         cloud_run: Optional[CloudRunServiceContainer] = None,
         gce_service_backend: Optional[GCEServiceBackend] = None,
+        include_http_redirect: bool = True,
     ) -> None:
         """Create a new CustomDomainMapping resource.
 
@@ -65,6 +67,7 @@ class CustomDomainMapping(GCPResource[CustomDomainMappingOutputs]):
         - `domain` (str): The domain to map to the Cloud Run service.
         - `cloud_run` (CloudRunServiceContainer): The Cloud Run service to map the domain to. One and only one of cloud_run and gce_service must be provided.
         - `regional_managed_instance_group` (RegionalManagedInstanceGroup): The Compute Engine service to map the domain to. One and only one of cloud_run and gce_service must be provided.
+        - `include_http_redirect` (bool): Whether to include an HTTP redirect to the HTTPS URL. Defaults to True.
         """
         super().__init__(
             name=name,
@@ -72,6 +75,7 @@ class CustomDomainMapping(GCPResource[CustomDomainMappingOutputs]):
         self.domain = domain
         self.cloud_run = cloud_run
         self.regional_managed_instance_group = gce_service_backend
+        self.include_http_redirect = include_http_redirect
 
         if not cloud_run and not gce_service_backend:
             raise ValueError(
@@ -119,4 +123,5 @@ class CustomDomainMapping(GCPResource[CustomDomainMappingOutputs]):
             health_check=health_check,
             region=region,
             named_port=named_port,
+            include_http_redirect=self.include_http_redirect,
         )

--- a/launchflow/gcp/custom_domain_mapping.py
+++ b/launchflow/gcp/custom_domain_mapping.py
@@ -12,7 +12,6 @@ from launchflow.models.flow_state import EnvironmentState
 from launchflow.node import Depends, Outputs
 from launchflow.resource import ResourceInputs
 from launchflow.service import DNSOutputs, DNSRecord
-from launchflow import exceptions
 
 
 @dataclasses.dataclass

--- a/launchflow/gcp/global_ip_address.py
+++ b/launchflow/gcp/global_ip_address.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import Dict
 
 from launchflow.gcp.resource import GCPResource
 from launchflow.models.enums import ResourceProduct

--- a/launchflow/gcp/global_ip_address.py
+++ b/launchflow/gcp/global_ip_address.py
@@ -1,0 +1,48 @@
+import dataclasses
+from typing import Dict
+
+from launchflow.gcp.resource import GCPResource
+from launchflow.models.enums import ResourceProduct
+from launchflow.models.flow_state import EnvironmentState
+from launchflow.node import Outputs
+from launchflow.resource import ResourceInputs
+
+
+@dataclasses.dataclass
+class GlobalIPAddressOutputs(Outputs):
+    ip_address: str
+
+
+@dataclasses.dataclass
+class GlobalIPAddressInputs(ResourceInputs):
+    pass
+
+
+class GlobalIPAddress(GCPResource[GlobalIPAddressOutputs]):
+    """
+    A global ip address resource.
+
+    Like all [Resources](/docs/concepts/resources), this class configures itself across multiple [Environments](/docs/concepts/environments).
+
+    For more information see [the official documentation](https://cloud.google.com/compute/docs/ip-addresses).
+
+    ### Example Usage
+    ```python
+    import launchflow as lf
+
+    ip = lf.gcp.GlobalIPAddress("ip-addres")
+    ```
+    """
+
+    product = ResourceProduct.GCP_GLOBAL_IP_ADDRESS.value
+
+    def __init__(self, name: str) -> None:
+        """Create a new Global IP Address resource.
+
+        **Args:**
+        - `name (str)`: The name of the ip address.
+        """
+        super().__init__(name=name)
+
+    def inputs(self, environment_state: EnvironmentState) -> GlobalIPAddressInputs:
+        return GlobalIPAddressInputs(resource_id=self.resource_id)

--- a/launchflow/gcp/launchflow_cloud_releaser.py
+++ b/launchflow/gcp/launchflow_cloud_releaser.py
@@ -11,11 +11,11 @@ from launchflow.backend import LaunchFlowBackend
 from launchflow.clients.accounts_client import AccountsSyncClient
 from launchflow.clients.environments_client import EnvironmentsSyncClient
 from launchflow.config import config
+from launchflow.gcp.resource import GCPResource
 from launchflow.models.enums import ResourceProduct
 from launchflow.models.flow_state import EnvironmentState
 from launchflow.node import Outputs
 from launchflow.resource import ResourceInputs
-from launchflow.gcp.resource import GCPResource
 
 
 @dataclasses.dataclass

--- a/launchflow/gcp/regional_autoscaler.py
+++ b/launchflow/gcp/regional_autoscaler.py
@@ -1,5 +1,6 @@
 import dataclasses
 from typing import List, Literal
+
 from typing_extensions import Optional
 
 from launchflow.gcp.regional_managed_instance_group import RegionalManagedInstanceGroup

--- a/launchflow/gcp/regional_managed_instance_group.py
+++ b/launchflow/gcp/regional_managed_instance_group.py
@@ -1,5 +1,6 @@
 import dataclasses
 from typing import Literal, Optional
+
 from typing_extensions import List
 
 from launchflow import exceptions

--- a/launchflow/gcp/ssl.py
+++ b/launchflow/gcp/ssl.py
@@ -1,0 +1,58 @@
+import dataclasses
+from typing import List, Union
+
+from launchflow.gcp.resource import GCPResource
+from launchflow.models.enums import ResourceProduct
+from launchflow.models.flow_state import EnvironmentState
+from launchflow.node import Outputs
+from launchflow.resource import ResourceInputs
+
+
+@dataclasses.dataclass
+class ManagedSSLCertificateOutputs(Outputs):
+    domains: List[str]
+
+
+@dataclasses.dataclass
+class ManagedSSLCertificateInputs(ResourceInputs):
+    domains: List[str]
+
+
+class ManagedSSLCertificate(GCPResource[ManagedSSLCertificateOutputs]):
+    """
+    A manage ssl certificate resource.
+
+    Like all [Resources](/docs/concepts/resources), this class configures itself across multiple [Environments](/docs/concepts/environments).
+
+    For more information see [the official documentation](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs).
+
+    ### Example Usage
+    ```python
+    import launchflow as lf
+
+    ip = lf.gcp.GlobalIPAddress("ip-addres")
+    ```
+    """
+
+    product = ResourceProduct.GCP_MANAGED_SSL_CERTIFICATE.value
+
+    def __init__(self, name: str, domains: Union[List[str], str]) -> None:
+        """Create a new managed ssl certificate resource.
+
+        **Args:**
+        - `name (str)`: The name of the ip address.
+        - `domain (str)`: The domain of the ssl certificate.
+        """
+        super().__init__(name=name)
+        self.domains = []
+        if isinstance(domains, str):
+            self.domains.append(domains)
+        else:
+            self.domains = domains
+
+    def inputs(
+        self, environment_state: EnvironmentState
+    ) -> ManagedSSLCertificateInputs:
+        return ManagedSSLCertificateInputs(
+            resource_id=self.resource_id, domains=self.domains
+        )

--- a/launchflow/gcp/ssl.py
+++ b/launchflow/gcp/ssl.py
@@ -49,6 +49,7 @@ class ManagedSSLCertificate(GCPResource[ManagedSSLCertificateOutputs]):
             self.domains.append(domains)
         else:
             self.domains = domains
+            self.domains.sort()
 
     def inputs(
         self, environment_state: EnvironmentState

--- a/launchflow/gcp/utils.py
+++ b/launchflow/gcp/utils.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import requests
 

--- a/launchflow/models/enums.py
+++ b/launchflow/models/enums.py
@@ -34,6 +34,8 @@ class ResourceProduct(str, Enum):
     GCP_REGIONAL_AUTO_SCALER = "gcp_regional_auto_scaler"
     GCP_FIREBASE_PROJECT = "gcp_firebase_project"
     GCP_FIREBASE_HOSTING_SITE = "gcp_firebase_hosting_site"
+    GCP_GLOBAL_IP_ADDRESS = "gcp_global_ip_address"
+    GCP_MANAGED_SSL_CERTIFICATE = "gcp_managed_ssl_certificate"
     # AWS product types
     AWS_RDS_POSTGRES = "aws_rds_postgres"
     AWS_ELASTICACHE_REDIS = "aws_elasticache_redis"

--- a/launchflow/models/utils.py
+++ b/launchflow/models/utils.py
@@ -26,6 +26,7 @@ from launchflow.gcp.custom_domain_mapping import CustomDomainMapping
 from launchflow.gcp.firebase import FirebaseHostingSite, FirebaseProject
 from launchflow.gcp.firebase_site import FirebaseStaticSite
 from launchflow.gcp.gcs import BackendBucket, GCSBucket
+from launchflow.gcp.global_ip_address import GlobalIPAddress
 from launchflow.gcp.http_health_check import HttpHealthCheck
 from launchflow.gcp.launchflow_cloud_releaser import (
     LaunchFlowCloudReleaser as GCPReleaser,
@@ -36,6 +37,7 @@ from launchflow.gcp.pubsub import PubsubSubscription, PubsubTopic
 from launchflow.gcp.regional_autoscaler import RegionalAutoscaler
 from launchflow.gcp.regional_managed_instance_group import RegionalManagedInstanceGroup
 from launchflow.gcp.secret_manager import SecretManagerSecret
+from launchflow.gcp.ssl import ManagedSSLCertificate
 from launchflow.gcp.static_site import StaticSite
 from launchflow.gcp.workbench import WorkbenchInstance
 from launchflow.models.enums import ResourceProduct, ServiceProduct
@@ -69,6 +71,8 @@ RESOURCE_PRODUCTS_TO_RESOURCES = {
     ResourceProduct.GCP_FIREWALL_ALLOW_RULE.value: FirewallAllowRule,
     ResourceProduct.GCP_COMPUTE_HTTP_HEALTH_CHECK.value: HttpHealthCheck,
     ResourceProduct.GCP_REGIONAL_AUTO_SCALER.value: RegionalAutoscaler,
+    ResourceProduct.GCP_GLOBAL_IP_ADDRESS.value: GlobalIPAddress,
+    ResourceProduct.GCP_MANAGED_SSL_CERTIFICATE.value: ManagedSSLCertificate,
     # AWS product types
     ResourceProduct.AWS_RDS_POSTGRES.value: RDSPostgres,
     ResourceProduct.AWS_ELASTICACHE_REDIS.value: ElasticacheRedis,

--- a/launchflow/workflows/commands/tf_commands.py
+++ b/launchflow/workflows/commands/tf_commands.py
@@ -152,7 +152,7 @@ class TFCommand:
                 # Upload the state to launchflow
                 with open(tf_state_path, "r") as f:
                     state = json.load(f)
-                with httpx.Client() as client:
+                with httpx.Client(timeout=60) as client:
                     response = client.post(
                         f"{self.backend.lf_cloud_url}/v1/projects/{self.launchflow_state_url}",
                         json=state,

--- a/launchflow/workflows/commands/tf_commands.py
+++ b/launchflow/workflows/commands/tf_commands.py
@@ -14,8 +14,8 @@ from launchflow import exceptions
 from launchflow.backend import GCSBackend, LaunchFlowBackend, LocalBackend
 from launchflow.config import config
 from launchflow.dependencies import opentofu
-from launchflow.utils import logging_output
 from launchflow.logger import logger
+from launchflow.utils import logging_output
 
 _GCS_BACKEND_TEMPLATE = """
 terraform {

--- a/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/main.tf
+++ b/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/main.tf
@@ -4,10 +4,6 @@ provider "google" {
 }
 
 
-resource "google_compute_global_address" "default" {
-  name = "${var.resource_id}-global-address"
-}
-
 # HTTPS Load Balancer setup
 resource "google_compute_global_forwarding_rule" "default" {
   name                  = "${var.resource_id}-forwarding-rule"
@@ -15,21 +11,15 @@ resource "google_compute_global_forwarding_rule" "default" {
   port_range            = "443"
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL_MANAGED"
-  ip_address            = google_compute_global_address.default.address
+  ip_address            = var.ip_address_id
 }
 
 resource "google_compute_target_https_proxy" "default" {
   name             = "${var.resource_id}-https-proxy"
   url_map          = google_compute_url_map.default.id
-  ssl_certificates = [google_compute_managed_ssl_certificate.default.id]
+  ssl_certificates = [var.ssl_certificate_id]
 }
 
-resource "google_compute_managed_ssl_certificate" "default" {
-  name = "${var.resource_id}-ssl-certificate"
-  managed {
-    domains = [var.domain]
-  }
-}
 
 resource "google_compute_url_map" "default" {
   name = var.resource_id
@@ -83,7 +73,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL_MANAGED"
   description           = "Forwarding rule for HTTP -> HTTPS redirect for ${var.resource_id}"
-  ip_address            = google_compute_global_address.default.address
+  ip_address            = var.ip_address_id
 }
 
 resource "google_compute_target_http_proxy" "default" {
@@ -100,20 +90,6 @@ resource "google_compute_url_map" "http_redirect" {
     https_redirect = true
     strip_query    = false
   }
-}
-
-
-output "ip_address" {
-  value = google_compute_global_forwarding_rule.default.ip_address
-}
-
-output "registered_domain" {
-  value = var.domain
-}
-
-output "ssl_certificate_id" {
-
-  value = google_compute_managed_ssl_certificate.default.id
 }
 
 

--- a/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/main.tf
+++ b/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/main.tf
@@ -69,7 +69,6 @@ resource "google_compute_region_network_endpoint_group" "cloud_run_neg" {
 }
 
 # HTTP Proxy setup
-# TODO: add the option to turn this off
 resource "google_compute_global_forwarding_rule" "http" {
   count                 = var.include_http_redirect ? 1 : 0
   name                  = "${var.resource_id}-http-forwarding-rule"

--- a/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/main.tf
+++ b/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/main.tf
@@ -3,6 +3,11 @@ provider "google" {
   region  = var.gcp_region
 }
 
+
+resource "google_compute_global_address" "default" {
+  name = "${var.resource_id}-global-address"
+}
+
 # HTTPS Load Balancer setup
 resource "google_compute_global_forwarding_rule" "default" {
   name                  = "${var.resource_id}-forwarding-rule"
@@ -10,6 +15,7 @@ resource "google_compute_global_forwarding_rule" "default" {
   port_range            = "443"
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL_MANAGED"
+  ip_address            = google_compute_global_address.default.address
 }
 
 resource "google_compute_target_https_proxy" "default" {
@@ -77,6 +83,7 @@ resource "google_compute_global_forwarding_rule" "http" {
   ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL_MANAGED"
   description           = "Forwarding rule for HTTP -> HTTPS redirect for ${var.resource_id}"
+  ip_address            = google_compute_global_address.default.address
 }
 
 resource "google_compute_target_http_proxy" "default" {

--- a/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/variables.tf
+++ b/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/variables.tf
@@ -24,7 +24,11 @@ variable "artifact_bucket" {
 #
 # Custom domain mapping specific fields
 #
-variable "domain" {
+variable "ip_address_id" {
+  type = string
+}
+
+variable "ssl_certificate_id" {
   type = string
 }
 

--- a/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/variables.tf
+++ b/launchflow/workflows/tf/resources/gcp_custom_domain_mapping/variables.tf
@@ -52,3 +52,8 @@ variable "named_port" {
   type    = string
   default = null
 }
+
+variable "include_http_redirect" {
+  type    = bool
+  default = true
+}

--- a/launchflow/workflows/tf/resources/gcp_global_ip_address/main.tf
+++ b/launchflow/workflows/tf/resources/gcp_global_ip_address/main.tf
@@ -1,0 +1,16 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}
+
+resource "google_compute_global_address" "default" {
+  name = var.resource_id
+}
+
+output "gcp_id" {
+  value = google_compute_global_address.default.id
+}
+
+output "ip_address" {
+  value = google_compute_global_address.default.address
+}

--- a/launchflow/workflows/tf/resources/gcp_global_ip_address/variables.tf
+++ b/launchflow/workflows/tf/resources/gcp_global_ip_address/variables.tf
@@ -1,0 +1,19 @@
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "environment_service_account_email" {
+  type = string
+}
+
+variable "resource_id" {
+  type = string
+}
+
+variable "artifact_bucket" {
+  type = string
+}

--- a/launchflow/workflows/tf/resources/gcp_global_ip_address/versions.tf
+++ b/launchflow/workflows/tf/resources/gcp_global_ip_address/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  # NOTE: This is configured at runtime with `tofu init`
+  # backend "gcs" {
+  # }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.19.0"
+    }
+  }
+}

--- a/launchflow/workflows/tf/resources/gcp_managed_ssl_certificate/main.tf
+++ b/launchflow/workflows/tf/resources/gcp_managed_ssl_certificate/main.tf
@@ -1,0 +1,19 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+}
+
+resource "google_compute_managed_ssl_certificate" "default" {
+  name = var.resource_id
+  managed {
+    domains = var.domains
+  }
+}
+
+output "gcp_id" {
+  value = google_compute_managed_ssl_certificate.default.id
+}
+
+output "domains" {
+  value = google_compute_managed_ssl_certificate.default.managed[0].domains
+}

--- a/launchflow/workflows/tf/resources/gcp_managed_ssl_certificate/variables.tf
+++ b/launchflow/workflows/tf/resources/gcp_managed_ssl_certificate/variables.tf
@@ -1,0 +1,23 @@
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "environment_service_account_email" {
+  type = string
+}
+
+variable "resource_id" {
+  type = string
+}
+
+variable "artifact_bucket" {
+  type = string
+}
+
+variable "domains" {
+  type = list(string)
+}

--- a/launchflow/workflows/tf/resources/gcp_managed_ssl_certificate/versions.tf
+++ b/launchflow/workflows/tf/resources/gcp_managed_ssl_certificate/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  # NOTE: This is configured at runtime with `tofu init`
+  # backend "gcs" {
+  # }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.19.0"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pyyaml",
     "pathspec",
     "pydantic>=2.0",
-    "deepdiff",
+    "deepdiff!=8.0.0",
     "typer",
     "requests",
     "httpx",

--- a/scripts/docs-generator/main.py
+++ b/scripts/docs-generator/main.py
@@ -8,13 +8,13 @@ pip install -r requirements.txt
 python main.py
 """
 
-from collections import deque
 import os
 import re
 import subprocess
 import sys
 import tempfile
-from typing import Deque, Any, TextIO
+from collections import deque
+from typing import Any, Deque, TextIO
 
 import docspec
 from pydoc_markdown.contrib.loaders.python import PythonLoader
@@ -22,7 +22,6 @@ from pydoc_markdown.contrib.processors.filter import FilterProcessor
 from pydoc_markdown.contrib.renderers.markdown import MarkdownRenderer
 from pydoc_markdown.interfaces import Context
 from pydoc_markdown.util.misc import escape_except_blockquotes
-
 
 KNOWN_RESOURCE_SERVICE_SUPER_CLASSES = {
     "Resource",

--- a/tests/integration/integration_tests/environments_integration_tests.py
+++ b/tests/integration/integration_tests/environments_integration_tests.py
@@ -1,7 +1,7 @@
 import os
 import random
-import time
 import subprocess
+import time
 import unittest
 from typing import List
 

--- a/tests/integration/integration_tests/local-backend/Dockerfile.gcp
+++ b/tests/integration/integration_tests/local-backend/Dockerfile.gcp
@@ -38,6 +38,7 @@ ENV PATH="${PATH}:/usr/local/lib/python3.11/site-packages/bin"
 WORKDIR /code
 COPY --chown=appuser:appuser ./app /code/app
 COPY --chown=appuser:appuser ./launchflow.yaml /code/launchflow.yaml
+COPY --chown=appuser:appuser ./.launchflow /code/.launchflow
 
 # Expose the port the app runs on
 EXPOSE $PORT

--- a/tests/integration/integration_tests/local-backend/app/infra.py
+++ b/tests/integration/integration_tests/local-backend/app/infra.py
@@ -10,14 +10,23 @@ environment = environment_manager.load_environment_sync()
 
 if environment.gcp_config is not None:
     bucket = lf.gcp.GCSBucket(f"{lf.project}-{lf.environment}-gcs-bucket")
-    run_service = lf.gcp.CloudRun("fastapi-service", dockerfile="Dockerfile.gcp")
+    run_service = lf.gcp.CloudRun(
+        "fastapi-service",
+        dockerfile="Dockerfile.gcp",
+        domain="cr.launchflow.app",
+    )
     gce_service = lf.gcp.compute_engine_service.ComputeEngineService(
-        "gce-service", dockerfile="Dockerfile.gcp", port=8080
+        "gce-service",
+        dockerfile="Dockerfile.gcp",
+        port=8080,
+        domain="gce.launchflow.app",
     )
 elif environment.aws_config is not None:
     bucket = lf.aws.S3Bucket(f"{lf.project}-{lf.environment}-s3-bucket")
     run_service = lf.aws.ECSFargate(
-        "fastapi-service", dockerfile="Dockerfile.aws", port=8080
+        "fastapi-service",
+        dockerfile="Dockerfile.aws",
+        port=8080,
     )
 else:
     raise AssertionError("Environment wasn't set up properly")

--- a/tests/integration/integration_tests/local-backend/requirements.txt
+++ b/tests/integration/integration_tests/local-backend/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 gunicorn
-git+https://github.com/launchflow/launchflow.git@provider-enum#egg=launchflow[gcp,aws]
+git+https://github.com/launchflow/launchflow.git@http-https-redirect#egg=launchflow[gcp,aws]
 uvicorn


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->
Resolves #38 

## Pull Request Description

Automatically setup an http -> https redirect for custom domains, and allow it to be turned off also

To make sure this works in the future I pulled out ssl cert and ip address out into separate resources. This makes them more reusable if the user needs to pull them out and use them for other things

## Testing

Tested starting a new service from scratch and it worked fine. Running the integration tests to verify they work also

Unfortunately users will have to delete they're existing custom domain and recreate it to get it to work.

To do this users can run:
```
lf destroy --resource=custom-domain-resource
lf create
```

Then this will print out the new DNS mapping