### PR TITLE
fix: block bad deepdiff version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pyyaml",
     "pathspec",
     "pydantic>=2.0",
-    "deepdiff",
+    "deepdiff!=8.0.0",
     "typer",
     "requests",
     "httpx",


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->

## Pull Request Description

Deepdiff released a new version that has a dependency on numpy that isn't listed in their dependencies, block this version until it is resolved

<!-- Please describe your changes in detail. -->

## Testing

Automated testing