### PR TITLE
fix: ensure ecs task definition can be updated without rolling back the image

### DIFF
--- a/docs/src/app/reference/aws-resources/ecs-fargate-container/page.md
+++ b/docs/src/app/reference/aws-resources/ecs-fargate-container/page.md
@@ -16,8 +16,6 @@ Creates a new ECS Fargate service container.
 **Args:**
 - `name (str)`: The name of the ECS Fargate service container.
 - `ecs_cluster (Union[ECSCluster, str])`: The ECS cluster or the name of the ECS cluster.
-- `cpu (int)`: The CPU units to allocate to the container. Defaults to 256.
-- `memory (int)`: The memory to allocate to the container. Defaults to 512.
 - `port (int)`: The port the container listens on. Defaults to 80.
 - `desired_count (int)`: The number of tasks to run. Defaults to 1.
 

--- a/launchflow/aws/ecs_fargate.py
+++ b/launchflow/aws/ecs_fargate.py
@@ -29,8 +29,6 @@ from launchflow.resource import Resource
 class ECSFargateInputs(Inputs):
     cpu: int = 256
     memory: int = 512
-    port: int = 80
-    desired_count: int = 1
 
 
 class ECSFargate(AWSDockerService):
@@ -150,10 +148,8 @@ class ECSFargate(AWSDockerService):
             name,
             self._ecs_cluster,
             alb=self._alb,
-            cpu=cpu,
-            memory=memory,
-            port=port,
             desired_count=desired_count,
+            port=port,
         )
         self._ecs_fargate_service_container.resource_id = (
             resource_id_with_launchflow_prefix
@@ -167,8 +163,6 @@ class ECSFargate(AWSDockerService):
         return ECSFargateInputs(
             cpu=self.cpu,
             memory=self.memory,
-            port=self.port,
-            desired_count=self.desired_count,
         )
 
     def resources(self) -> List[Resource]:

--- a/launchflow/aws/ecs_fargate_container.py
+++ b/launchflow/aws/ecs_fargate_container.py
@@ -15,8 +15,6 @@ from launchflow.resource import ResourceInputs
 class ECSFargateServiceContainerInputs(ResourceInputs):
     resource_name: str
     ecs_cluster_name: str
-    cpu: int = 256
-    memory: int = 512
     port: int = 80
     desired_count: int = 1
     alb_security_group_id: Optional[str] = None
@@ -46,8 +44,6 @@ class ECSFargateServiceContainer(AWSResource[ECSFargateServiceContainerOutputs])
         name: str,
         ecs_cluster: Union[ECSCluster, str],
         alb: Optional[ApplicationLoadBalancer] = None,
-        cpu: int = 256,
-        memory: int = 512,
         port: int = 80,
         desired_count: int = 1,
     ) -> None:
@@ -56,8 +52,6 @@ class ECSFargateServiceContainer(AWSResource[ECSFargateServiceContainerOutputs])
         **Args:**
         - `name (str)`: The name of the ECS Fargate service container.
         - `ecs_cluster (Union[ECSCluster, str])`: The ECS cluster or the name of the ECS cluster.
-        - `cpu (int)`: The CPU units to allocate to the container. Defaults to 256.
-        - `memory (int)`: The memory to allocate to the container. Defaults to 512.
         - `port (int)`: The port the container listens on. Defaults to 80.
         - `desired_count (int)`: The number of tasks to run. Defaults to 1.
 
@@ -75,8 +69,6 @@ class ECSFargateServiceContainer(AWSResource[ECSFargateServiceContainerOutputs])
         )
         self.ecs_cluster = ecs_cluster
         self.alb = alb
-        self.cpu = cpu
-        self.memory = memory
         self.port = port
         self.desired_count = desired_count
 
@@ -110,8 +102,6 @@ class ECSFargateServiceContainer(AWSResource[ECSFargateServiceContainerOutputs])
             resource_id=self.resource_id,
             resource_name=self.name,
             ecs_cluster_name=ecs_cluster_name,
-            cpu=self.cpu,
-            memory=self.memory,
             port=self.port,
             desired_count=self.desired_count,
             alb_security_group_id=alb_security_group_id,

--- a/launchflow/workflows/deploy_aws_service.py
+++ b/launchflow/workflows/deploy_aws_service.py
@@ -414,6 +414,16 @@ async def release_docker_image_to_ecs_fargate(
         del new_task_definition["containerDefinitions"][0]["command"]
     if "entryPoint" in new_task_definition["containerDefinitions"][0]:
         del new_task_definition["containerDefinitions"][0]["entryPoint"]
+    # Update the port mappings
+    new_task_definition["containerDefinitions"][0]["portMappings"] = [
+        {
+            "containerPort": ecs_fargate_service.port,
+            "hostPort": ecs_fargate_service.port,
+        }
+    ]
+    # Update the cpu and memory
+    new_task_definition["cpu"] = str(ecs_fargate_service.cpu)
+    new_task_definition["memory"] = str(ecs_fargate_service.memory)
 
     # Add the environment variables
     new_task_definition["containerDefinitions"][0]["environment"] = [

--- a/launchflow/workflows/tf/resources/aws_ecs_fargate_service_container/variables.tf
+++ b/launchflow/workflows/tf/resources/aws_ecs_fargate_service_container/variables.tf
@@ -46,14 +46,6 @@ variable "resource_name" {
   type = string
 }
 
-variable "cpu" {
-  type = number
-}
-
-variable "memory" {
-  type = number
-}
-
 variable "port" {
   type = number
 }

--- a/tests/integration/integration_tests/local-backend/app/infra.py
+++ b/tests/integration/integration_tests/local-backend/app/infra.py
@@ -24,9 +24,7 @@ if environment.gcp_config is not None:
 elif environment.aws_config is not None:
     bucket = lf.aws.S3Bucket(f"{lf.project}-{lf.environment}-s3-bucket")
     run_service = lf.aws.ECSFargate(
-        "fastapi-service",
-        dockerfile="Dockerfile.aws",
-        port=8080,
+        "fastapi-service", dockerfile="Dockerfile.aws", port=8080, desired_count=2
     )
 else:
     raise AssertionError("Environment wasn't set up properly")

--- a/tests/integration/integration_tests/local-backend/requirements.txt
+++ b/tests/integration/integration_tests/local-backend/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 gunicorn
-git+https://github.com/launchflow/launchflow.git@http-https-redirect#egg=launchflow[gcp,aws]
+git+https://github.com/launchflow/launchflow.git#egg=launchflow[gcp,aws]
 uvicorn


### PR DESCRIPTION
<!-- If your PR resolves an issue, please add it here. -->
Resolves #58 

## Pull Request Description

This decouples updating the image from updating the fargate configuration. I modeled this similar to how we model gce services. So updating the cpu / mem is done as part of the deploy phase as opposed to the create. This is because with fargate we are technically pushing a new task definition not a new image.

Users can pass the `--skip-build` flag if they want to just update the cpu / mem without building a new image

There were a couple other small fixes I made to.
- Remove the open port for the ecs tasks now that we have the load balancer in front. This helps secure the individual tasks
- update docs for the new params

## Testing

Tested this by creating a new fargate service and then updating the cpu / memory. Then verified there was 0 downtime and the container image stayed the same. Also verified that updating things on the service itself like `desired_count` doesn't cause a rollback of the container. Here's what the "new" plan looks like:

![Screenshot 2024-08-29 at 12 05 18 PM](https://github.com/user-attachments/assets/7df3b59b-8d83-4b3b-89ca-7f810d7bc817)


